### PR TITLE
find pybind11 before ament_cmake to fix error on Ubuntu 22.04

### DIFF
--- a/.github/workflows/pr_todo_checks.yml
+++ b/.github/workflows/pr_todo_checks.yml
@@ -7,10 +7,9 @@ jobs:
     name: New FIXMEs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: git fetch origin ${GITHUB_BASE_REF}
+    - uses: actions/checkout@v3
     - name: Check for FIXMEs
-      uses: luator/github_action_check_new_todos@v1
+      uses: luator/github_action_check_new_todos@v2
       with:
           label: FIXME
           base_ref: origin/${{ github.base_ref }}
@@ -19,10 +18,9 @@ jobs:
     name: New TODOs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: git fetch origin ${GITHUB_BASE_REF}
+    - uses: actions/checkout@v3
     - name: Check for TODOs
-      uses: luator/github_action_check_new_todos@v1
+      uses: luator/github_action_check_new_todos@v2
       with:
           label: TODO
           base_ref: origin/${{ github.base_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
+### Fixed
+- pybind11 build error on Ubuntu 22.04
 
 
 ## [2.0.0] - 2022-06-29

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ install(
 if (BUILD_TESTING)
     find_package(ament_cmake_nose REQUIRED)
 
+    # Need to install a dummy package with __init__.py, otherwise the package
+    # will not be added to PYTHONPATH in the setup.bash and the pybind11 module
+    # installed below will not be found.
+    ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR test/dummy_pkg/${PROJECT_NAME})
     add_pybind11_module(cvbind_test srcpy/cvbind_test.cpp
         LINK_LIBRARIES ${PROJECT_NAME}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,14 @@ project(pybind11_opencv)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
+# pybind11 needs to be first, otherwise other packages which also search for
+# Python can cause an 'Unknown CMake command "python3_add_library"' error.
+# Probably related to how Python is found, see
+# https://github.com/pybind/pybind11/issues/3996
+find_package(pybind11 REQUIRED)
+
 find_package(ament_cmake REQUIRED)
 find_package(mpi_cmake_modules REQUIRED)
-find_package(pybind11 REQUIRED)
 find_package(OpenCV REQUIRED)
 
 


### PR DESCRIPTION
## Description

See title.
There was a further issue that the module build for the test was not found anymore.  This is fixed by installing an empty Python package via ament.


## How I Tested

By building locally and running the tests.