### PR TITLE
chore: Bump versions in GitHub workflows

### DIFF
--- a/.github/workflows/pr_todo_checks.yml
+++ b/.github/workflows/pr_todo_checks.yml
@@ -7,7 +7,7 @@ jobs:
     name: New FIXMEs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check for FIXMEs
       uses: luator/github_action_check_new_todos@v2
       with:
@@ -18,7 +18,7 @@ jobs:
     name: New TODOs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check for TODOs
       uses: luator/github_action_check_new_todos@v2
       with:

--- a/.github/workflows/style_checker.yml
+++ b/.github/workflows/style_checker.yml
@@ -5,10 +5,10 @@ on: [pull_request]
 jobs:
   clang-format:
     name: C++ Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/scripts/run-clang-format
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/resources/_clang-format
       - run: python ./run-clang-format -r .


### PR DESCRIPTION
- Use ubuntu-latest instead of ubuntu-20.04 (20.04 will be disabled soon).
- Bump actions/checkout and setup-python to latest versions.
