### PR TITLE
Fixes for ROS Jazzy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ target_link_libraries(${PROJECT_NAME} INTERFACE
 ## Install ##
 #############
 
-ament_export_interfaces(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 # Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
@@ -67,6 +66,7 @@ if (BUILD_TESTING)
 endif()
 
 
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
 ament_export_dependencies(pybind11 OpenCV)
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ install(
 #############
 
 if (BUILD_TESTING)
-    find_package(ament_cmake_nose REQUIRED)
+    find_package(ament_cmake_pytest REQUIRED)
 
     # Need to install a dummy package with __init__.py, otherwise the package
     # will not be added to PYTHONPATH in the setup.bash and the pybind11 module
@@ -63,7 +63,7 @@ if (BUILD_TESTING)
         LINK_LIBRARIES ${PROJECT_NAME}
     )
 
-    ament_add_nose_test(test_cvbind test/test_cvbind.py)
+    ament_add_pytest_test(test_cvbind test/test_cvbind.py)
 endif()
 
 

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <depend>libopencv-dev</depend>
   <depend>pybind11</depend>
 
-  <test_depend>ament_cmake_nose</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <export>
       <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Two fixes that were needed to build the package with ROS Jazzy (Ubuntu 24.04):

- Rename `ament_export_interfaces` to `ament_export_targets`.
- Use `ament_cmake_pytest` instead of `ament_cmake_nose` (which doesn't exist anymore).  Existing tests work with pytest as well, so no need for further modifications.